### PR TITLE
Typings generalization

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,9 @@
 declare namespace sizeSensor {
-    export const bind: (
-        element: HTMLElement | null,
-        cb: (element: HTMLElement | null) => void
+    type StyledElement = Element & ElementCSSInlineStyle;
+    export const bind: <T extends StyledElement = HTMLElement>(
+        element: T | null,
+        cb: (element: T | null) => void
     ) => () => void;
-    export const clear: (element: HTMLElement | null) => void;
+    export const clear: (element: StyledElement | null) => void;
 }
 export = sizeSensor;


### PR DESCRIPTION
It's entirely possible to use this library for handling SVG elements (and possibly any other ones, as long as they have the `style` property) - in fact, this is used in frappe-gantt React wrapper. But the typings state that only the HTML elements are supported.
This PR tries to generalize the typengs to allow other types of elements to be handled in a sound way.