### PR TITLE
fix: add "tabindex: -1" during new sensor object creation

### DIFF
--- a/src/constant.js
+++ b/src/constant.js
@@ -8,3 +8,5 @@ export const SizeSensorId = 'size-sensor-id';
 export const SensorStyle = 'display:block;position:absolute;top:0;left:0;height:100%;width:100%;overflow:hidden;pointer-events:none;z-index:-1;opacity:0';
 
 export const SensorClassName = 'size-sensor-object';
+
+export const SensorTabIndex = '-1';

--- a/src/sensors/object.js
+++ b/src/sensors/object.js
@@ -4,7 +4,7 @@
  */
 
 import debounce from '../debounce';
-import { SensorStyle, SensorClassName } from '../constant';
+import { SensorStyle, SensorClassName, SensorTabIndex } from '../constant';
 
 export const createSensor = element => {
   // 感应器
@@ -30,6 +30,7 @@ export const createSensor = element => {
     };
     obj.setAttribute('style', SensorStyle);
     obj.setAttribute('class', SensorClassName);
+    obj.setAttribute('tabindex', SensorTabIndex);
     obj.type = 'text/html';
 
     // 添加到 dom 结构中


### PR DESCRIPTION
Added `tabindex: -1` to sensor object to make it unfocusable