### PR TITLE
Update constant.js

### DIFF
--- a/src/constant.js
+++ b/src/constant.js
@@ -5,7 +5,7 @@
 
 export const SizeSensorId = 'size-sensor-id';
 
-export const SensorStyle = 'display:block;position:absolute;top:0;left:0;height:100%;width:100%;overflow:hidden;pointer-events:none;z-index:-1;opacity:0';
+export const SensorStyle = 'display:block;position:absolute;top:0;left:0;height:100%;width:auto;overflow:hidden;pointer-events:none;z-index:-1;opacity:0';
 
 export const SensorClassName = 'size-sensor-object';
 


### PR DESCRIPTION
在 windows 系统中屏幕内容放大率大于 100% 时，利用 echarts-for-react 绘制 echars-wordcloud 时width:100% 会导致 resizeListener() 死循环