### PR TITLE
fix: explicit style setting for CSP conformity

### DIFF
--- a/src/constant.js
+++ b/src/constant.js
@@ -5,8 +5,6 @@
 
 export const SizeSensorId = 'size-sensor-id';
 
-export const SensorStyle = 'display:block;position:absolute;top:0;left:0;height:100%;width:auto;overflow:hidden;pointer-events:none;z-index:-1;opacity:0';
-
 export const SensorClassName = 'size-sensor-object';
 
 export const SensorTabIndex = '-1';

--- a/src/sensors/object.js
+++ b/src/sensors/object.js
@@ -27,7 +27,16 @@ export const createSensor = element => {
       // 直接触发一次 resize
       resizeListener();
     };
-    obj.setAttribute('style', SensorStyle);
+    obj.style.display = 'block'
+    obj.style.position = 'absolute'
+    obj.style.top = '0'
+    obj.style.left = '0'
+    obj.style.height = '100%'
+    obj.style.width = 'auto'
+    obj.style.overflow = 'hidden'
+    obj.style.pointerEvents = 'none'
+    obj.style.zIndex = '-1'
+    obj.style.opacity = '0'
     obj.setAttribute('class', SensorClassName);
     obj.setAttribute('tabindex', SensorTabIndex);
     obj.type = 'text/html';


### PR DESCRIPTION
Should fix #12 by removing the need to specify content-security policy`styleSrc: unsafe-inline` when using this library.

I removed the string constant that contained all the sensor's styles and replaced it by an explicit style setting via [JS style API](https://developer.mozilla.org/en-US/docs/Web/API/ElementCSSInlineStyle/style) (which is generally allowed by content-security policies).

I realise that this is a bit more verbose but I think being more explicit here increases security, because it removes a "magic string".

Other options would have been to
- Add a separate `<style>` tag with `nonce` attribute as initially suggested in #12, but this would be a lot more work and it's also more work on the server to generate a proper nonce and transmit it to the client.
- Offload all CSS into a separate `.css` file: obviously more work, and probably too much overhead for the only 10 style rules that need to be set.