### PR TITLE
fix: Add null check in destroy() before disconnecting sensor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "size-sensor",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "DOM element size sensor which will callback when size changed.",
   "main": "lib/index.js",
   "types": "index.d.ts",

--- a/src/sensors/resizeObserver.js
+++ b/src/sensors/resizeObserver.js
@@ -53,7 +53,9 @@ export const createSensor = (element, whenDestroy) => {
    * destroy
    */
   const destroy = () => {
-    sensor.disconnect();
+    if (sensor) {
+      sensor.disconnect();
+    }
 
     listeners = [];
     sensor = undefined;


### PR DESCRIPTION
## Description

  Fixes #20 

  Adds a null check before `sensor.disconnect()` to prevent `TypeError` in React StrictMode.

  ## Changes

  **File**: `lib/sensors/resizeObserver.js`

  ```diff
    var destroy = function destroy() {
  +   if (sensor) {
        sensor.disconnect();
  +   }
      listeners = [];
      sensor = undefined;
      element.removeAttribute(_constant.SizeSensorId);
      whenDestroy && whenDestroy();
    };
```

  ## Why This Fix Works

  React StrictMode intentionally double-mounts components to detect side effects. Without the null check:
  1. First destroy(): ✅ sensor.disconnect() succeeds → sensor = undefined
  2. Second destroy(): ❌ sensor.disconnect() throws TypeError

  With the null check, both calls complete safely.

  ## Testing

  ✅ Tested in production environment:
  - React 19.2.0 with StrictMode enabled
  - echarts-for-react 3.0.5 (uses size-sensor)
  - Multiple mount/unmount cycles
  - No console errors after fix

  ## Backward Compatibility

  ✅ Fully backward compatible
  - Only adds defensive null check
  - No API changes
  - No behavior changes in normal usage

  ## Related

  Similar fixes in other libraries:
  - https://github.com/souporserious/react-measure/issues/108